### PR TITLE
Small fixes after reading through the code

### DIFF
--- a/src/main/java/frc/robot/AutoModeSelector.java
+++ b/src/main/java/frc/robot/AutoModeSelector.java
@@ -13,7 +13,8 @@ public class AutoModeSelector {
         // autoModeChooser.addOption("Drop and drive (yellow side)",
         // dropAndDriveYellow(container));
         autoModeChooser.addOption("Drop and balance", dropAndBalanceYellow(container));
-        autoModeChooser.addOption("Drop, Mobility, and balance", dropMobilityAndBalance(container));
+        autoModeChooser.addOption("1 Piece Mobility Balance (any preload)", dropMobilityAndBalance(container));
+        autoModeChooser.addOption("1.5 Balance (Yellow Preload Only)", oneHalfBalance(container));
         // autoModeChooser.addOption("Drop, drive, strafe, and pickup", new
         // DropAndDriveAndStrafeAndPickup(container));
         // autoModeChooser.addOption("Middle Pickup (red)",
@@ -22,12 +23,12 @@ public class AutoModeSelector {
         // middlePickupStraight(container, false));
         // autoModeChooser.addOption("Middle Pickup Balance",
         // middlePickupBalance(container));
-        autoModeChooser.addOption("Bump side Yellow + Mobility", new DropMobilityChargeSide(container));
-        autoModeChooser.addOption("2 Purple Barrier (red)", twoPiecePurpleBarrier(container, true));
-        autoModeChooser.addOption("2 Purple Barrier (blue)", twoPiecePurpleBarrier(container, false));
-        autoModeChooser.addOption("OneHalfBalance (Yellow Only)", oneHalfBalance(container));
-        autoModeChooser.addOption("Bump Side Two Purple (Red)", bumpSideTwoPurple(container, true));
-        autoModeChooser.addOption("Bump Side Two Purple (Blue)", bumpSideTwoPurple(container, false));
+
+        autoModeChooser.addOption("Flat Side 2 Purple (Red)", twoPiecePurpleBarrier(container, true));
+        autoModeChooser.addOption("Flat Side 2 Purple (Blue)", twoPiecePurpleBarrier(container, false));
+        autoModeChooser.addOption("Bump Side 2 Purple (Red)", bumpSideTwoPurple(container, true));
+        autoModeChooser.addOption("Bump Side 2 Purple (Blue)", bumpSideTwoPurple(container, false));
+        autoModeChooser.addOption("Bump side 1 Yellow + Mobility", new DropMobilityChargeSide(container));
     }
 
     public SendableChooser<Command> getAutoChooser() {

--- a/src/main/java/frc/robot/autos/BumpSideTwoPurple.java
+++ b/src/main/java/frc/robot/autos/BumpSideTwoPurple.java
@@ -37,12 +37,11 @@ public class BumpSideTwoPurple extends SequentialCommandGroup {
         addCommands(new PivotMoveToPosition(container.getPivot(), Constants.PivotConstants.kPositionScoringCube));
         addCommands(
                 new TelescopicScoringExtendFar(container.getTelescopic(), container.getPivot()).withTimeout(.55));
-        // Open gripper
+        // Open gripper to score pre load
         addCommands(new GripperRelease(container.getGripper())
                 .withTimeout(Constants.GripperConstants.kGripperReleaseTimeout));
 
-        // retract arm and pivot up to vertical, also start driving to middle to pickup
-        // purple
+        // retract arm and pivot up to vertical, also start driving to bump
         addCommands(new ParallelCommandGroup(new Command[] {
                 new TelescopicRetract(container.getTelescopic()).withTimeout(1.0),
                 new PivotMoveToPosition(container.getPivot(), Constants.PivotConstants.kPositionTravel)
@@ -52,23 +51,25 @@ public class BumpSideTwoPurple extends SequentialCommandGroup {
 
         }));
 
+        // extend intake and pivot to purple pickup position. Drive to purple pickup
+        // location
         addCommands(new ParallelRaceGroup(new Command[] {
                 new SeqCmdCubePickupPosition(container.getTelescopic(),
                         container.getConeGuide(),
                         container.getGripper(), container.getIntake(), container.gIntakeSpinner(),
                         container.getPivot()),
-                new PIDTranslateForAuto(container.getSwerve(), purplePickup, OffsetNeeded.Y, false)
+                new PIDTranslateForAuto(container.getSwerve(), purplePickup, OffsetNeeded.None, false)
         }));
 
         // close gripper
         addCommands(new GripperRetrieve(container.getGripper())
                 .withTimeout(Constants.GripperConstants.kGripperReleaseTimeout));
-
+        // extend intake to avoid knocking purple out of grip
         addCommands(new IntakeExtend(
                 container.getIntake(),
                 container.getPivot(), false));
 
-        // scoring position and drive back to score
+        // scoring position and drive back to bump
         addCommands(new ParallelCommandGroup(
                 new CmdGrpScoringPosition(container.getConeGuide(), container.getTelescopic(),
                         container.getPivot()),
@@ -78,8 +79,8 @@ public class BumpSideTwoPurple extends SequentialCommandGroup {
                                         .getEncoder() >= Constants.PivotConstants.kPositionForSafeIntakeRetract),
                         new IntakeRetract(container.getIntake())
                 }),
-                new PIDTranslateForAuto(container.getSwerve(), bumpInbound, OffsetNeeded.Y, false)));
-
+                new PIDTranslateForAuto(container.getSwerve(), bumpInbound, OffsetNeeded.None, false)));
+        // drive from bump to scoring location
         addCommands(new PIDTranslateForAuto(container.getSwerve(), scoringLocation, OffsetNeeded.Y, true));
 
         // extend arm
@@ -114,16 +115,18 @@ public class BumpSideTwoPurple extends SequentialCommandGroup {
     public static Pose2d bumpOutbound_Red = new Pose2d(14.87 - 2, 1.04, Rotation2d.fromDegrees(0));
     public static Pose2d bumpInbound_Red = new Pose2d(14.87 - 2.5, 1.04, Rotation2d.fromDegrees(0));
     public static Pose2d purplePickup_Red = new Pose2d(14.87 - 5.5, 1.04 - 0.05, Rotation2d.fromDegrees(0));
-    public static Pose2d scoringLocation_Red = new Pose2d(14.92, 1.07, Rotation2d.fromDegrees(0));
+    public static Pose2d scoringLocation_Red = new Pose2d(14.92, 1.07, Rotation2d.fromDegrees(0)); // TODO: Same as Red
+                                                                                                   // Purple 1
     public static Pose2d yellowPickup_Red = new Pose2d(14.87 - 6, 1.04 + 1.2, Rotation2d.fromDegrees(0));
 
     /* Blue Paths */
     /* ========== */
 
-    public static Pose2d startPosition_Blue = new Pose2d(1.64, 4.35, Rotation2d.fromDegrees(0));
-    public static Pose2d bumpOutbound_Blue = new Pose2d(1.64 + 2, 4.35, Rotation2d.fromDegrees(0));
-    public static Pose2d bumpInbound_Blue = new Pose2d(1.64 + 2.5, 4.35, Rotation2d.fromDegrees(0));
-    public static Pose2d purplePickup_Blue = new Pose2d(1.64 + 5.5, 4.35 - 0.05, Rotation2d.fromDegrees(0));
-    public static Pose2d scoringLocation_Blue = new Pose2d(1.59, 4.38, Rotation2d.fromDegrees(0));
-    public static Pose2d yellowPickup_Blue = new Pose2d(1.64 + 6, 4.35 + 1.2, Rotation2d.fromDegrees(0));
+    public static Pose2d startPosition_Blue = new Pose2d(1.64, 1.04, Rotation2d.fromDegrees(0));
+    public static Pose2d bumpOutbound_Blue = new Pose2d(1.64 + 2, 1.04, Rotation2d.fromDegrees(0));
+    public static Pose2d bumpInbound_Blue = new Pose2d(1.64 + 2.5, 1.04, Rotation2d.fromDegrees(0));
+    public static Pose2d purplePickup_Blue = new Pose2d(1.64 + 5.5, 1.04 - 0.05, Rotation2d.fromDegrees(0));
+    public static Pose2d scoringLocation_Blue = new Pose2d(1.59, 1.07, Rotation2d.fromDegrees(0)); // TODO: Same as Blue
+                                                                                                   // Purple 3
+    public static Pose2d yellowPickup_Blue = new Pose2d(1.64 + 6, 1.04 + 1.2, Rotation2d.fromDegrees(0));
 }

--- a/src/main/java/frc/robot/autos/OneHalfBalance.java
+++ b/src/main/java/frc/robot/autos/OneHalfBalance.java
@@ -36,13 +36,15 @@ public class OneHalfBalance extends SequentialCommandGroup {
                 new PivotMoveToPosition(container.getPivot(), Constants.PivotConstants.kPositionTravel)
                         .withTimeout(1.0) }));
 
-        addCommands(new ParallelCommandGroup(new Command[] {
+        // start driving over charge station. After 1.5 seconds move pivot to pickup and
+        // extend intake. Command should end when end of path reached.
+        addCommands(new ParallelRaceGroup(new Command[] {
                 new SequentialCommandGroup(new Command[] {
                         new WaitCommand(1.5),
                         new SeqCmdCubePickupPosition(container.getTelescopic(),
                                 container.getConeGuide(),
                                 container.getGripper(), container.getIntake(), container.gIntakeSpinner(),
-                                container.getPivot()).withTimeout(2)
+                                container.getPivot())
                 }),
                 AutoFollowPath.createFollowCommand(container.getSwerve(),
                         pDropToMobility)
@@ -69,7 +71,7 @@ public class OneHalfBalance extends SequentialCommandGroup {
                 }),
                 AutoFollowPath.createFollowCommand(container.getSwerve(),
                         pDropAndBalanceYellowSide1)));
-
+        // drive up charge station and balance
         addCommands(new ParallelRaceGroup(AutoFollowPath.createFollowCommand(container.getSwerve(),
                 pDropAndBalanceYellowSide1),
                 new AwaitLevelCharge(container.getSwerve())));

--- a/src/main/java/frc/robot/autos/TwoPiecePurpleBarrier.java
+++ b/src/main/java/frc/robot/autos/TwoPiecePurpleBarrier.java
@@ -53,7 +53,7 @@ public class TwoPiecePurpleBarrier extends SequentialCommandGroup {
         // close gripper
         addCommands(new GripperRetrieve(container.getGripper())
                 .withTimeout(Constants.GripperConstants.kGripperReleaseTimeout));
-
+        // extend intake to avoid collisions with cube
         addCommands(new IntakeExtend(
                 container.getIntake(),
                 container.getPivot(), false));
@@ -99,7 +99,8 @@ public class TwoPiecePurpleBarrier extends SequentialCommandGroup {
 
     public static Pose2d startPosition_Red = new Pose2d(14.87, 4.38, Rotation2d.fromDegrees(180));
     public static Pose2d purplePickup_Red = new Pose2d(14.87 - 5.1, 4.38 + 0.05, Rotation2d.fromDegrees(0));
-    public static Pose2d scoringLocation_Red = new Pose2d(15.00, 4.44, Rotation2d.fromDegrees(0));
+    public static Pose2d scoringLocation_Red = new Pose2d(15.00, 4.44, Rotation2d.fromDegrees(0)); // TODO: Same as Red
+                                                                                                   // Purple 3
     public static Pose2d yellowPickup_Red = new Pose2d(14.87 - 6, 4.38 - 1.2, Rotation2d.fromDegrees(0));
 
     /* Blue Paths */
@@ -107,6 +108,7 @@ public class TwoPiecePurpleBarrier extends SequentialCommandGroup {
 
     public static Pose2d startPosition_Blue = new Pose2d(1.64, 4.35, Rotation2d.fromDegrees(0));
     public static Pose2d purplePickup_Blue = new Pose2d(1.64 + 5.1, 4.35 + 0.05, Rotation2d.fromDegrees(0));
-    public static Pose2d scoringLocation_Blue = new Pose2d(1.64, 4.43, Rotation2d.fromDegrees(0));
+    public static Pose2d scoringLocation_Blue = new Pose2d(1.64, 4.43, Rotation2d.fromDegrees(0)); // TODO: Same as Blue
+                                                                                                   // Purple 1
     public static Pose2d yellowPickup_Blue = new Pose2d(1.64 + 6, 4.35 - 1.2, Rotation2d.fromDegrees(0));
 }


### PR DESCRIPTION
Can you guys read through and make sure I didnt make any errors? I think these changes are important. I added comments for clarity around the scoring locations, and fixed some logic. The 1.5 balance should keep the intake spinning now (same logic fix as the bump side auto with a race group). 

- Automode selector -> renamed & reordered autos in the list to make more sense.
- BumpSideTwoPurple -> changed offset to none for some of the paths that were copied and pasted incorrectly. Also updated the blue points to a safer starting point (they were from the flat side still). Will still need to be tuned at the event. Also added comments.
- OneHalfBalance -> removed timeout and changed parallel command to race. This should fix the intake not spinning when trying to pickup to floor purple. Also added comments.
- TwoPiecePurpleBarrier -> added comments