### PR TITLE
Ruckus adjustments

### DIFF
--- a/src/main/java/frc/robot/commands/AwaitLevelCharge.java
+++ b/src/main/java/frc/robot/commands/AwaitLevelCharge.java
@@ -21,7 +21,7 @@ public class AwaitLevelCharge extends CommandBase {
 
     @Override
     public void execute() {
-        if (Math.abs(swerve.getRawPitch()) > 20.0) {
+        if (Math.abs(swerve.getRawPitch()) > 18.0) {
             liftoff = true;
         }
     }

--- a/src/main/java/frc/robot/common/Nodes.java
+++ b/src/main/java/frc/robot/common/Nodes.java
@@ -44,24 +44,24 @@ public class Nodes {
 
         redTranslations = new Translation2d[] {
 
-                new Translation2d(14.94, 0.55), // Yellow 1
-                new Translation2d(14.96, 1.63), // Yellow 2
-                new Translation2d(14.86, 2.23), // Yellow 3
-                new Translation2d(14.92, 3.32), // Yellow 4
-                new Translation2d(14.89, 3.87), // Yellow 5
-                new Translation2d(14.90, 4.97), // Yellow 6
+                new Translation2d(14.94, 0.54), // Yellow 1
+                new Translation2d(14.96, 1.66), // Yellow 2
+                new Translation2d(14.86, 2.22), // Yellow 3
+                new Translation2d(14.92, 3.33), // Yellow 4
+                new Translation2d(14.89, 3.88), // Yellow 5
+                new Translation2d(14.90, 5), // Yellow 6
                 new Translation2d(14.92, 1.09), // purple 1
                 new Translation2d(14.92, 2.76), // purple 2
                 new Translation2d(14.92, 4.44), // purple 3
         };
         blueTranslations = new Translation2d[] {
 
-                new Translation2d(1.64, 4.97), // yellow 1
-                new Translation2d(1.64, 3.85), // yellow 2
+                new Translation2d(1.64, 4.975), // yellow 1
+                new Translation2d(1.64, 3.845), // yellow 2
                 new Translation2d(1.64, 3.28), // yelllow 3
-                new Translation2d(1.61, 2.17), // yellow 4
-                new Translation2d(1.63, 1.595), // yellow 5
-                new Translation2d(1.62, 0.475), // yellow 6
+                new Translation2d(1.61, 2.175), // yellow 4
+                new Translation2d(1.63, 1.6), // yellow 5
+                new Translation2d(1.62, 0.485), // yellow 6
                 new Translation2d(1.64, 4.41), // purple 1
                 new Translation2d(1.63, 2.72), // purple 2
                 new Translation2d(1.63, 1.03), // purple 3


### PR DESCRIPTION
- Nodes calibration
- Lower climbing angle to account for less than optimal charging station. This inscreases the sensitivity to detect when the robot started climbing.